### PR TITLE
REFACTOR : 저장소 개선 계획 P0-P2 반영

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gradle
+build
+out
+**/*.log
+**/.DS_Store
+README.md
+ORGANIZATION_README.md
+.cursor
+agent-transcripts
+mcps

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,6 +19,17 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  STAGING_HEALTH_URL: ${{ secrets.STAGING_HEALTH_URL }}
+  PRODUCTION_HEALTH_URL: ${{ secrets.PRODUCTION_HEALTH_URL }}
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+concurrency:
+  group: carecode-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # ===========================================
@@ -31,6 +42,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
       
     - name: Set up JDK 17
       uses: actions/setup-java@v4
@@ -49,7 +65,7 @@ jobs:
           ${{ runner.os }}-gradle-
           
     - name: Run tests
-      run: ./gradlew test
+      run: ./gradlew clean test jacocoTestReport
       
     - name: Build application
       run: ./gradlew build -x test
@@ -72,9 +88,14 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
       
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.30.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
@@ -97,7 +118,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     
     outputs:
-      image-tag: ${{ steps.meta.outputs.tags }}
+      image-tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
       
     steps:
     - name: Checkout code
@@ -150,14 +171,22 @@ jobs:
       
     - name: Deploy to staging environment
       run: |
-        echo "Deploying to staging environment (Green)"
-        # 여기에 실제 배포 스크립트 추가
-        # 예: SSH를 통한 원격 서버 배포 또는 클라우드 플랫폼 배포
+        test -n "${{ secrets.STAGING_DEPLOY_HOST }}"
+        ssh -o StrictHostKeyChecking=no ${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }} \
+          "docker pull ${{ needs.build-docker.outputs.image-tag }} && docker stop carecode-staging || true && docker rm carecode-staging || true && docker run -d --name carecode-staging -p 8082:8082 --env-file /opt/carecode/.env ${{ needs.build-docker.outputs.image-tag }}"
         
     - name: Run health check
       run: |
-        echo "Running health check for staging environment"
-        # 헬스체크 스크립트 추가
+        test -n "$STAGING_HEALTH_URL"
+        for i in {1..20}; do
+          if curl -fsS "$STAGING_HEALTH_URL/actuator/health" | grep -q '"status":"UP"'; then
+            echo "Staging health check passed"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "Staging health check failed"
+        exit 1
         
     - name: Notify deployment status
       if: always()
@@ -182,8 +211,7 @@ jobs:
     - name: Determine deployment strategy
       id: strategy
       run: |
-        # 현재 활성 환경 확인 (Blue 또는 Green)
-        CURRENT_ENV=$(curl -s http://your-domain.com/admin/current-env || echo "blue")
+        CURRENT_ENV=$(curl -fsS "${{ secrets.PRODUCTION_ROUTER_STATUS_URL }}" || echo "blue")
         if [ "$CURRENT_ENV" = "blue" ]; then
           echo "target-env=green" >> $GITHUB_OUTPUT
           echo "current-env=blue" >> $GITHUB_OUTPUT
@@ -194,29 +222,42 @@ jobs:
         
     - name: Deploy to target environment
       run: |
-        echo "Deploying to ${{ steps.strategy.outputs.target-env }} environment"
-        # 대상 환경에 새 버전 배포
+        test -n "${{ secrets.PRODUCTION_DEPLOY_HOST }}"
+        ssh -o StrictHostKeyChecking=no ${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }} \
+          "docker pull ${{ needs.build-docker.outputs.image-tag }} && docker stop carecode-${{ steps.strategy.outputs.target-env }} || true && docker rm carecode-${{ steps.strategy.outputs.target-env }} || true && docker run -d --name carecode-${{ steps.strategy.outputs.target-env }} -p 8082:8082 --env-file /opt/carecode/.env ${{ needs.build-docker.outputs.image-tag }}"
         
     - name: Wait for deployment to be ready
       run: |
-        echo "Waiting for ${{ steps.strategy.outputs.target-env }} environment to be ready"
-        # 배포 완료 대기 및 헬스체크
+        test -n "$PRODUCTION_HEALTH_URL"
+        for i in {1..20}; do
+          if curl -fsS "$PRODUCTION_HEALTH_URL/actuator/health" | grep -q '"status":"UP"'; then
+            echo "Production target is healthy"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "Production health check failed"
+        exit 1
         
     - name: Switch traffic to new environment
       run: |
-        echo "Switching traffic to ${{ steps.strategy.outputs.target-env }} environment"
-        # Nginx 설정 업데이트 또는 로드밸런서 설정 변경
+        test -n "${{ secrets.PRODUCTION_ROUTER_SWITCH_URL }}"
+        curl -fsS -X POST "${{ secrets.PRODUCTION_ROUTER_SWITCH_URL }}" \
+          -H "Authorization: Bearer ${{ secrets.PRODUCTION_ROUTER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d "{\"target\":\"${{ steps.strategy.outputs.target-env }}\"}"
         
     - name: Verify deployment
       run: |
-        echo "Verifying deployment"
-        # 배포 검증 (응답 시간, 에러율 등)
+        curl -fsS "$PRODUCTION_HEALTH_URL/actuator/health" | grep -q '"status":"UP"'
         
     - name: Rollback if needed
       if: failure()
       run: |
-        echo "Rolling back to ${{ steps.strategy.outputs.current-env }} environment"
-        # 실패 시 이전 환경으로 롤백
+        curl -fsS -X POST "${{ secrets.PRODUCTION_ROUTER_SWITCH_URL }}" \
+          -H "Authorization: Bearer ${{ secrets.PRODUCTION_ROUTER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d "{\"target\":\"${{ steps.strategy.outputs.current-env }}\"}"
         
     - name: Notify deployment status
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,30 @@
 # 1단계: Gradle로 빌드
-FROM gradle:7.6.2-jdk17 AS builder
+FROM gradle:8.14.2-jdk17 AS builder
 
 WORKDIR /app
 COPY . .
 
-RUN gradle clean build --no-daemon
+RUN gradle clean bootJar --no-daemon
 
 # 2단계: JDK 17로 실행용 이미지 구성
 FROM openjdk:17-jdk-slim
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
 
 WORKDIR /app
 
 # 빌드된 JAR 복사 (하나만 있는 경우 자동 복사 가능)
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/build/libs/carecode-app.jar app.jar
 
-EXPOSE 8080
+RUN addgroup --system carecode && adduser --system --ingroup carecode carecode
+RUN chown -R carecode:carecode /app
+USER carecode
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+EXPOSE 8082
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8082/actuator/health | grep -q '"status":"UP"' || exit 1
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.carecode'
@@ -74,6 +75,33 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy(tasks.named('jacocoTestReport'))
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('jacocoTestCoverageVerification')
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.30
+            }
+        }
+    }
 }
 
 // JAR 빌드 최적화

--- a/scripts/generate-asciidoc.sh
+++ b/scripts/generate-asciidoc.sh
@@ -44,7 +44,7 @@ log_info "CareCode API 문서 생성을 시작합니다..."
 
 # 애플리케이션이 실행 중인지 확인
 check_app_running() {
-    if curl -s http://localhost:8080/health > /dev/null 2>&1; then
+    if curl -s http://localhost:8082/actuator/health > /dev/null 2>&1; then
         return 0
     else
         return 1

--- a/src/main/java/com/carecode/core/aspect/AuthenticationAspect.java
+++ b/src/main/java/com/carecode/core/aspect/AuthenticationAspect.java
@@ -32,7 +32,7 @@ public class AuthenticationAspect {
         if (authentication == null || !authentication.isAuthenticated() || 
             "anonymousUser".equals(authentication.getName())) {
             log.warn("인증되지 않은 사용자의 접근 시도: {}", joinPoint.getSignature().getName());
-            throw new CareServiceException(requireAuthentication.message());
+            throw new CareServiceException("UNAUTHORIZED", requireAuthentication.message());
         }
         
         // 역할 기반 권한 확인 (필요한 경우)
@@ -50,7 +50,7 @@ public class AuthenticationAspect {
             if (!hasRequiredRole) {
                 log.warn("권한이 없는 사용자의 접근 시도: {} (필요한 역할: {})", 
                     joinPoint.getSignature().getName(), String.join(", ", requiredRoles));
-                throw new CareServiceException("접근 권한이 없습니다.");
+                throw new CareServiceException("FORBIDDEN", "접근 권한이 없습니다.");
             }
         }
         

--- a/src/main/java/com/carecode/core/config/CorsConfig.java
+++ b/src/main/java/com/carecode/core/config/CorsConfig.java
@@ -1,13 +1,19 @@
 package com.carecode.core.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {
+    @Value("${app.security.cors.allowed-origins:http://localhost:3000,http://127.0.0.1:3000}")
+    private String allowedOrigins;
+
     @Bean
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -15,28 +21,19 @@ public class CorsConfig {
         
         // 자격 증명 허용
         config.setAllowCredentials(true);
-        
+
         // 허용할 Origins 설정
-        config.addAllowedOriginPattern("http://localhost:3000"); // Next.js 개발 서버
-        config.addAllowedOriginPattern("http://127.0.0.1:3000");
-        config.addAllowedOriginPattern("http://localhost:*");
-        config.addAllowedOriginPattern("*"); // 모든 오리진 허용 (개발용)
-        
-        // 허용할 헤더
-        config.addAllowedHeader("*");
-        
-        // 허용할 HTTP 메서드
-        config.addAllowedMethod("GET");
-        config.addAllowedMethod("POST");
-        config.addAllowedMethod("PUT");
-        config.addAllowedMethod("DELETE");
-        config.addAllowedMethod("OPTIONS");
-        config.addAllowedMethod("PATCH");
-        
-        // 노출할 헤더 (클라이언트에서 접근 가능)
-        config.addExposedHeader("Authorization");
-        config.addExposedHeader("X-Refresh-Token");
-        config.addExposedHeader("X-New-User");
+        config.setAllowedOriginPatterns(
+                Arrays.stream(allowedOrigins.split(","))
+                        .map(String::trim)
+                        .filter(origin -> !origin.isEmpty())
+                        .toList()
+        );
+
+        // 허용할 헤더/메서드/노출 헤더
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        config.setExposedHeaders(List.of("Authorization", "X-Refresh-Token", "X-New-User"));
         
         // 모든 경로에 CORS 설정 적용
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/carecode/core/handler/CustomizedResponseEntityExceptionHandler.java
+++ b/src/main/java/com/carecode/core/handler/CustomizedResponseEntityExceptionHandler.java
@@ -4,14 +4,12 @@ import com.carecode.core.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -101,10 +99,8 @@ public class CustomizedResponseEntityExceptionHandler {
     @ExceptionHandler(CareServiceException.class)
     public ResponseEntity<ErrorResponse> handleCareServiceException(CareServiceException ex, WebRequest request) {
         log.error("CareServiceException 발생: {} - {}", ex.getErrorCode(), ex.getMessage(), ex);
-        
-        ErrorCode errorCode = ex.getErrorCode() != null 
-            ? ErrorCode.INTERNAL_SERVER_ERROR 
-            : ErrorCode.INTERNAL_SERVER_ERROR;
+
+        ErrorCode errorCode = resolveCareServiceErrorCode(ex.getErrorCode());
         
         ErrorResponse errorResponse = ErrorResponse.of(
             errorCode,
@@ -113,8 +109,18 @@ public class CustomizedResponseEntityExceptionHandler {
         );
         
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .status(errorCode.getHttpStatus())
                 .body(errorResponse);
+    }
+
+    private ErrorCode resolveCareServiceErrorCode(String careServiceErrorCode) {
+        if ("UNAUTHORIZED".equalsIgnoreCase(careServiceErrorCode)) {
+            return ErrorCode.UNAUTHORIZED;
+        }
+        if ("FORBIDDEN".equalsIgnoreCase(careServiceErrorCode)) {
+            return ErrorCode.FORBIDDEN;
+        }
+        return ErrorCode.INTERNAL_SERVER_ERROR;
     }
 
 

--- a/src/main/java/com/carecode/core/security/SecurityConfig.java
+++ b/src/main/java/com/carecode/core/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.carecode.core.security;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +16,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Spring Security 설정
@@ -26,11 +29,17 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomUserDetailsService customUserDetailsService;
+    private final List<String> allowedOrigins;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, 
-                         CustomUserDetailsService customUserDetailsService) {
+                         CustomUserDetailsService customUserDetailsService,
+                         @Value("${app.security.cors.allowed-origins:http://localhost:3000,http://127.0.0.1:3000}") String allowedOrigins) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.customUserDetailsService = customUserDetailsService;
+        this.allowedOrigins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toList();
     }
 
     @Bean
@@ -39,9 +48,10 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(request -> {
                 CorsConfiguration configuration = new CorsConfiguration();
                 configuration.setAllowCredentials(true);
-                configuration.addAllowedOriginPattern("*");
-                configuration.addAllowedHeader("*");
-                configuration.addAllowedMethod("*");
+                configuration.setAllowedOriginPatterns(allowedOrigins);
+                configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept"));
+                configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+                configuration.setExposedHeaders(List.of("Authorization", "X-Refresh-Token"));
                 return configuration;
             })) // CORS 활성화
             .csrf(AbstractHttpConfigurer::disable)
@@ -64,7 +74,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authz -> authz
                 // 공개 엔드포인트
                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers("/actuator/**").permitAll()
+                .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                 .requestMatchers("/", "/error", "/favicon.ico").permitAll()
                 
                 // 정적 리소스 (공개 접근)
@@ -89,6 +99,8 @@ public class SecurityConfig {
                 
                 // 관리자 API (ADMIN 권한 필요)
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .requestMatchers("/admin/login").permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
                 
                 // 공개 API 엔드포인트
                 .requestMatchers("/facilities").permitAll()

--- a/src/main/java/com/carecode/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/com/carecode/domain/admin/controller/AdminDashboardController.java
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import com.carecode.core.components.JsonMapComponent;
+import java.time.LocalDateTime;
 
 @Controller
 @RequestMapping("/admin")
@@ -42,8 +43,7 @@ public class AdminDashboardController {
 
         // 2. 최근 활동 (최신순 5개)
         List<Map<String, String>> recentActivities = new ArrayList<>();
-        List<User> allUsers = userRepository.findAll();
-        allUsers.sort(Comparator.comparing(User::getCreatedAt).reversed());
+        List<User> allUsers = userRepository.findTop2ByDeletedAtIsNullOrderByCreatedAtDesc();
 
         for (int i = 0; i < Math.min(2, allUsers.size()); i++) {
             User user = allUsers.get(i);
@@ -54,8 +54,7 @@ public class AdminDashboardController {
             ));
         }
 
-        List<Hospital> allHospitals = hospitalRepository.findAll();
-        allHospitals.sort(Comparator.comparing(Hospital::getCreatedAt).reversed());
+        List<Hospital> allHospitals = hospitalRepository.findTop2ByOrderByCreatedAtDesc();
 
         for (int i = 0; i < Math.min(2, allHospitals.size()); i++) {
             Hospital hospital = allHospitals.get(i);
@@ -66,8 +65,7 @@ public class AdminDashboardController {
             ));
         }
 
-        List<Policy> allPolicies = policyRepository.findAll();
-        allPolicies.sort(Comparator.comparing(Policy::getCreatedAt).reversed());
+        List<Policy> allPolicies = policyRepository.findTop1ByOrderByCreatedAtDesc();
 
         for (int i = 0; i < Math.min(1, allPolicies.size()); i++) {
             Policy policy = allPolicies.get(i);
@@ -88,15 +86,18 @@ public class AdminDashboardController {
         // 3. 가입자 추이 (최근 6개월)
         Map<String, Long> userTrend = new LinkedHashMap<>();
         LocalDate now = LocalDate.now();
+        LocalDateTime sixMonthsAgo = now.minusMonths(5).withDayOfMonth(1).atStartOfDay();
+        List<Object[]> trendRows = userRepository.countUsersGroupedByMonthSince(sixMonthsAgo);
+        Map<String, Long> trendLookup = new HashMap<>();
+        for (Object[] row : trendRows) {
+            String key = String.format("%d-%02d", ((Number) row[0]).intValue(), ((Number) row[1]).intValue());
+            trendLookup.put(key, ((Number) row[2]).longValue());
+        }
 
         for (int i = 5; i >= 0; i--) {
             LocalDate monthVal = now.minusMonths(i).withDayOfMonth(1);
             String labelVal = monthVal.format(DateTimeFormatter.ofPattern("yyyy-MM"));
-            long count = userRepository.findAll().stream()
-                    .filter(u -> u.getCreatedAt() != null &&
-                            u.getCreatedAt().getYear() == monthVal.getYear() &&
-                            u.getCreatedAt().getMonthValue() == monthVal.getMonthValue())
-                    .count();
+            long count = trendLookup.getOrDefault(labelVal, 0L);
             userTrend.put(labelVal, count);
         }
 

--- a/src/main/java/com/carecode/domain/community/app/CommunityFacade.java
+++ b/src/main/java/com/carecode/domain/community/app/CommunityFacade.java
@@ -121,6 +121,11 @@ public class CommunityFacade {
     public long getBookmarkCount(Long postId) {
         return communityService.getBookmarkCount(postId);
     }
+
+    @Transactional(readOnly = true)
+    public Long getCurrentAuthenticatedUserId() {
+        return communityService.getCurrentAuthenticatedUserId();
+    }
 }
 
 

--- a/src/main/java/com/carecode/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/carecode/domain/community/controller/CommunityController.java
@@ -12,7 +12,6 @@ import com.carecode.domain.community.dto.response.CommunityPostDetailResponse;
 import com.carecode.domain.community.dto.response.CommunityCommentResponse;
 import com.carecode.domain.community.dto.response.CommunityTagResponse;
 import com.carecode.domain.community.dto.response.CommunityPageResponse;
-import com.carecode.domain.community.service.CommunityService;
 import com.carecode.domain.community.app.CommunityFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import com.carecode.core.handler.ApiSuccess;
 import java.util.Date;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * 커뮤니티 API 컨트롤러
@@ -225,9 +222,8 @@ public class CommunityController extends BaseController {
     @RequireAuthentication
     @Operation(summary = "게시글 좋아요", description = "게시글에 좋아요를 추가하거나 제거합니다.")
     public ResponseEntity<Map<String, Object>> toggleLike(
-            @Parameter(description = "게시글 ID", required = true) @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long postId) {
+        Long userId = communityFacade.getCurrentAuthenticatedUserId();
         boolean isLiked = communityFacade.toggleLike(postId, userId);
         long likeCount = communityFacade.getLikeCount(postId);
         
@@ -245,9 +241,8 @@ public class CommunityController extends BaseController {
     @RequireAuthentication
     @Operation(summary = "게시글 북마크", description = "게시글을 북마크에 추가하거나 제거합니다.")
     public ResponseEntity<Map<String, Object>> toggleBookmark(
-            @Parameter(description = "게시글 ID", required = true) @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long postId) {
+        Long userId = communityFacade.getCurrentAuthenticatedUserId();
         boolean isBookmarked = communityFacade.toggleBookmark(postId, userId);
         long bookmarkCount = communityFacade.getBookmarkCount(postId);
         
@@ -265,8 +260,8 @@ public class CommunityController extends BaseController {
     @RequireAuthentication
     @Operation(summary = "좋아요한 게시글 목록", description = "현재 사용자가 좋아요한 게시글 목록을 조회합니다.")
     public ResponseEntity<List<CommunityPostResponse>> getLikedPosts(
-            @AuthenticationPrincipal UserDetails userDetails) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+            ) {
+        Long userId = communityFacade.getCurrentAuthenticatedUserId();
         List<CommunityPostResponse> posts = communityFacade.getLikedPosts(userId);
         return ResponseEntity.ok(posts);
     }
@@ -279,8 +274,8 @@ public class CommunityController extends BaseController {
     @RequireAuthentication
     @Operation(summary = "북마크한 게시글 목록", description = "현재 사용자가 북마크한 게시글 목록을 조회합니다.")
     public ResponseEntity<List<CommunityPostResponse>> getBookmarkedPosts(
-            @AuthenticationPrincipal UserDetails userDetails) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+            ) {
+        Long userId = communityFacade.getCurrentAuthenticatedUserId();
         List<CommunityPostResponse> posts = communityFacade.getBookmarkedPosts(userId);
         return ResponseEntity.ok(posts);
     }

--- a/src/main/java/com/carecode/domain/community/service/CommunityService.java
+++ b/src/main/java/com/carecode/domain/community/service/CommunityService.java
@@ -558,21 +558,8 @@ public class CommunityService {
         return communityMapper.toPostResponseList(posts);
     }
 
-
-    // 현재 로그인한 사용자 ID 가져오기
-
-    private Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return null;
-        }
-
-        String username = authentication.getName();
-        if (username == null || username.equals("anonymousUser")) {
-            return null;
-        }
-
-        User user = userRepository.findByEmail(username).orElse(null);
-        return user != null ? user.getId() : null;
+    @Transactional(readOnly = true)
+    public Long getCurrentAuthenticatedUserId() {
+        return getCurrentUser().getId();
     }
 } 

--- a/src/main/java/com/carecode/domain/health/app/HealthFacade.java
+++ b/src/main/java/com/carecode/domain/health/app/HealthFacade.java
@@ -2,8 +2,6 @@ package com.carecode.domain.health.app;
 
 import com.carecode.domain.health.dto.request.HealthCreateHealthRecordRequest;
 import com.carecode.domain.health.dto.request.HealthUpdateHealthRecordRequest;
-import com.carecode.domain.health.dto.request.HealthCreateHospitalReviewRequest;
-import com.carecode.domain.health.dto.request.HealthUpdateHospitalReviewRequest;
 import com.carecode.domain.health.dto.response.HealthRecordResponse;
 import com.carecode.domain.health.dto.response.VaccineScheduleResponse;
 import com.carecode.domain.health.dto.response.CheckupScheduleResponse;
@@ -25,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import com.carecode.domain.health.mapper.HospitalMapper;
 import com.carecode.domain.health.mapper.HospitalReviewMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -163,8 +162,7 @@ public class HealthFacade {
     }
 
     public boolean unlikeHospital(Long id, Long userId) {
-        Hospital hospital = hospitalRepository.findById(id)
-                .orElseThrow(() -> new HospitalNotFoundException(id));
+        hospitalRepository.findById(id).orElseThrow(() -> new HospitalNotFoundException(id));
         
         // 좋아요를 누르지 않은 경우 false 반환
         if (!hospitalLikeRepository.existsByHospitalIdAndUserId(id, userId)) {
@@ -176,8 +174,7 @@ public class HealthFacade {
     }
 
     public long getLikeCount(Long id) {
-        Hospital hospital = hospitalRepository.findById(id)
-                .orElseThrow(() -> new HospitalNotFoundException(id));
+        hospitalRepository.findById(id).orElseThrow(() -> new HospitalNotFoundException(id));
         
         return hospitalLikeRepository.countByHospitalId(id);
     }
@@ -198,11 +195,9 @@ public class HealthFacade {
     }
 
     public List<HospitalInfoResponse> getPopularHospitals(int limit) {
-        return hospitalRepository.findAll().stream()
-                .sorted((h1, h2) -> Long.compare(
-                        hospitalLikeRepository.countByHospitalId(h2.getId()),
-                        hospitalLikeRepository.countByHospitalId(h1.getId())))
-                .limit(limit)
+        int safeLimit = Math.max(limit, 1);
+        return hospitalRepository.findPopularHospitals(PageRequest.of(0, safeLimit)).stream()
+                .limit(safeLimit)
                 .map(hospitalMapper::toResponse)
                 .toList();
     }

--- a/src/main/java/com/carecode/domain/health/repository/HospitalRepository.java
+++ b/src/main/java/com/carecode/domain/health/repository/HospitalRepository.java
@@ -4,6 +4,7 @@ import com.carecode.domain.health.entity.Hospital;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface HospitalRepository extends JpaRepository<Hospital, Long> {
@@ -11,4 +12,15 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
 
     @Query("SELECT h FROM Hospital h WHERE FUNCTION('ST_Distance_Sphere', point(h.longitude, h.latitude), point(:lng, :lat)) <= :radius")
     List<Hospital> findNearby(@Param("lat") double lat, @Param("lng") double lng, @Param("radius") double radius);
+
+    List<Hospital> findTop2ByOrderByCreatedAtDesc();
+
+    @Query("""
+           SELECT h
+           FROM Hospital h
+           LEFT JOIN HospitalLike hl ON hl.hospital.id = h.id
+           GROUP BY h
+           ORDER BY COUNT(hl.id) DESC
+           """)
+    List<Hospital> findPopularHospitals(Pageable pageable);
 } 

--- a/src/main/java/com/carecode/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/carecode/domain/policy/repository/PolicyRepository.java
@@ -28,6 +28,8 @@ public interface PolicyRepository extends JpaRepository<Policy, Long> {
     // 정책 유형별 조회
     List<Policy> findByPolicyType(String policyType);
 
+    List<Policy> findTop1ByOrderByCreatedAtDesc();
+
     // 지역별 정책 조회
     List<Policy> findByTargetRegion(String targetRegion);
 

--- a/src/main/java/com/carecode/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/carecode/domain/user/repository/UserRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -53,6 +51,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 사용자 역할별 조회 (삭제된 사용자 포함)
     List<User> findByRole(String role);
 
+    List<User> findTop2ByDeletedAtIsNullOrderByCreatedAtDesc();
+
     // 지역별 사용자 조회 (삭제된 사용자 포함)
     List<User> findByAddressContaining(String region);
 
@@ -85,6 +85,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일 인증된 사용자 수 조회 (삭제되지 않은 사용자만)
     @Query("SELECT COUNT(u) FROM User u WHERE u.emailVerified = true AND u.deletedAt IS NULL")
     long countEmailVerifiedUsersNotDeleted();
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.deletedAt IS NULL AND u.createdAt >= :since")
+    long countNewUsersSince(@Param("since") LocalDateTime since);
+
+    @Query("""
+           SELECT YEAR(u.createdAt), MONTH(u.createdAt), COUNT(u)
+           FROM User u
+           WHERE u.deletedAt IS NULL AND u.createdAt >= :since
+           GROUP BY YEAR(u.createdAt), MONTH(u.createdAt)
+           """)
+    List<Object[]> countUsersGroupedByMonthSince(@Param("since") LocalDateTime since);
 
     // OAuth2 제공자와 프로바이더 ID로 사용자 조회 (삭제되지 않은 사용자만)
     @Query("SELECT u FROM User u WHERE u.provider = :provider AND u.providerId = :providerId AND u.deletedAt IS NULL")

--- a/src/main/java/com/carecode/domain/user/service/JwtService.java
+++ b/src/main/java/com/carecode/domain/user/service/JwtService.java
@@ -5,6 +5,7 @@ import com.carecode.domain.user.dto.response.TokenValidationResponse;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +22,7 @@ import java.util.Map;
 @Service
 public class JwtService {
 
-    @Value("${jwt.secret:carecode-secret-key-for-jwt-token-generation}")
+    @Value("${jwt.secret}")
     private String secret;
 
     @Value("${jwt.access-token.expiration:3600000}") // 1시간
@@ -29,6 +30,16 @@ public class JwtService {
 
     @Value("${jwt.refresh-token.expiration:2592000000}") // 30일
     private long refreshTokenExpiration;
+
+    @PostConstruct
+    public void validateJwtSecret() {
+        if (secret == null || secret.trim().isEmpty()) {
+            throw new IllegalStateException("JWT secret must be configured.");
+        }
+        if (secret.length() < 32) {
+            throw new IllegalStateException("JWT secret must be at least 32 characters.");
+        }
+    }
 
     private SecretKey getSigningKey() {
         return Keys.hmacShaKeyFor(secret.getBytes());

--- a/src/main/java/com/carecode/domain/user/service/UserService.java
+++ b/src/main/java/com/carecode/domain/user/service/UserService.java
@@ -3,8 +3,6 @@ package com.carecode.domain.user.service;
 import com.carecode.core.annotation.LogExecutionTime;
 import com.carecode.core.annotation.RequireAuthentication;
 import com.carecode.core.exception.UserNotFoundException;
-import com.carecode.core.util.ValidationUtil;
-import com.carecode.domain.user.dto.request.LoginRequestDto;
 import com.carecode.domain.user.dto.request.PasswordChangeRequestDto;
 import com.carecode.domain.user.dto.response.UserDto;
 import com.carecode.domain.user.dto.response.UserStatsResponse;
@@ -14,7 +12,6 @@ import com.carecode.domain.user.entity.Gender;
 import com.carecode.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +26,7 @@ import java.util.stream.Collectors;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
@@ -44,6 +42,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RestTemplate restTemplate;
 
 
 
@@ -115,18 +114,17 @@ public class UserService {
         log.info("카카오 사용자 정보 조회 시작: accessToken={}", accessToken != null ? accessToken.substring(0, Math.min(20, accessToken.length())) + "..." : "null");
         
         try {
-            RestTemplate restTemplate = new RestTemplate();
             HttpHeaders headers = new HttpHeaders();
             headers.set("Authorization", "Bearer " + accessToken);
             headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
             HttpEntity<String> entity = new HttpEntity<>(headers);
             
             
-            ResponseEntity<Map> response = restTemplate.exchange(
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
                 "https://kapi.kakao.com/v2/user/me",
                 HttpMethod.GET,
                 entity,
-                Map.class
+                new ParameterizedTypeReference<>() {}
             );
             
             Map<String, Object> body = response.getBody();
@@ -140,10 +138,10 @@ public class UserService {
                 }
                 userInfo.put("id", kakaoId);
                 
-                Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
-                if (kakaoAccount != null && kakaoAccount.containsKey("profile")) {
-                    Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-                    if (profile != null) {
+                Object kakaoAccountObj = body.get("kakao_account");
+                if (kakaoAccountObj instanceof Map<?, ?> kakaoAccount) {
+                    Object profileObj = kakaoAccount.get("profile");
+                    if (profileObj instanceof Map<?, ?> profile) {
                         userInfo.put("nickname", profile.get("nickname"));
                         userInfo.put("profileImageUrl", profile.get("profile_image_url"));
                     }
@@ -173,25 +171,18 @@ public class UserService {
 
     @LogExecutionTime
     public UserStatsResponse getUserStatistics() {
-        List<User> allUsers = userRepository.findAll();
-        long totalUsers = allUsers.size();
-        long activeUsers = allUsers.stream().filter(u -> Boolean.TRUE.equals(u.getIsActive())).count();
-        long verifiedUsers = allUsers.stream().filter(u -> Boolean.TRUE.equals(u.getEmailVerified())).count();
+        long totalUsers = userRepository.count();
+        long activeUsers = userRepository.countActiveUsersNotDeleted();
+        long verifiedUsers = userRepository.countEmailVerifiedUsersNotDeleted();
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
         LocalDateTime startOfWeek = now.minusWeeks(1);
         LocalDateTime startOfMonth = now.minusMonths(1);
 
-        long newUsersToday = allUsers.stream()
-                .filter(u -> u.getCreatedAt() != null && !u.getCreatedAt().isBefore(startOfToday))
-                .count();
-        long newUsersThisWeek = allUsers.stream()
-                .filter(u -> u.getCreatedAt() != null && !u.getCreatedAt().isBefore(startOfWeek))
-                .count();
-        long newUsersThisMonth = allUsers.stream()
-                .filter(u -> u.getCreatedAt() != null && !u.getCreatedAt().isBefore(startOfMonth))
-                .count();
+        long newUsersToday = userRepository.countNewUsersSince(startOfToday);
+        long newUsersThisWeek = userRepository.countNewUsersSince(startOfWeek);
+        long newUsersThisMonth = userRepository.countNewUsersSince(startOfMonth);
 
         return UserStatsResponse.builder()
                 .totalUsers(totalUsers)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,8 +28,8 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: validate
+    show-sql: false
     properties:
       hibernate:
         format_sql: true
@@ -114,9 +114,9 @@ logging:
   level:
     com.carecode: INFO
     com.carecode.core.security: INFO
-    com.carecode.domain.user.service.JwtService: DEBUG
-    org.springframework.security: DEBUG
-    org.springframework.security.oauth2: DEBUG
+    com.carecode.domain.user.service.JwtService: INFO
+    org.springframework.security: INFO
+    org.springframework.security.oauth2: INFO
     org.springframework.web: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
@@ -126,7 +126,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus,env,httptrace
+        include: health,info,prometheus
       base-path: /actuator
   endpoint:
     health:


### PR DESCRIPTION
## 🏫 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🏫 반영 브랜치
`fix/repository-improvement-plan-p0-p2` -> `release`

## 🏫 변경 사항
이번 PR은 저장소 개선 계획(P0/P1/P2)을 한 번에 반영한 리팩터링/안정화 작업입니다.  
핵심 목적은 **보안 노출 리스크 축소**, **트래픽 증가 시 성능 병목 제거**, **배포/운영 신뢰성 강화**입니다.

### 1) 보안/권한(P0)
- 운영 설정 하드닝
  - `application-prod.yml`
    - `ddl-auto: update -> validate`
    - `show-sql: true -> false`
    - 보안 관련 DEBUG 로그를 INFO로 조정
    - Actuator 노출을 `health,info,prometheus`로 최소화
- Security 설정 보강
  - `SecurityConfig`
    - 기존 `"/actuator/**" permitAll` 제거
    - 허용 endpoint 최소화 (`/actuator/health`, `/actuator/info`, `/actuator/prometheus`)
    - CORS를 wildcard에서 **allowlist 기반**으로 전환
    - `/admin/**` 접근 제어 보강 (`/admin/login`만 permit)
- JWT 비밀키 안정성 강화
  - `JwtService`
    - 기본값 fallback 제거
    - secret 미설정/길이 부족 시 애플리케이션 fail-fast
- 인증 예외 상태코드 정합성 개선
  - `AuthenticationAspect`, `CustomizedResponseEntityExceptionHandler`
    - 인증/인가 실패 케이스를 500이 아닌 401/403으로 명확히 응답
- 커뮤니티 사용자 식별 버그 수정
  - `CommunityController`, `CommunityFacade`, `CommunityService`
    - `@AuthenticationPrincipal` username을 숫자(Long)로 파싱하던 경로 제거
    - 인증 컨텍스트 기반 사용자 식별로 일원화

### 2) 성능 개선(P1)
- 인기 병원 조회 쿼리 최적화
  - `HealthFacade`, `HospitalRepository`
    - 전체 병원 로드 후 정렬 시 반복 count 조회하던 패턴 제거
    - DB 집계 쿼리(`GROUP BY + COUNT`) 기반으로 전환
- 사용자 통계 조회 최적화
  - `UserService`, `UserRepository`
    - `findAll()` + stream count 제거
    - repository count/집계 쿼리 사용으로 메모리/CPU 부담 감소
- 관리자 대시보드 조회 최적화
  - `AdminDashboardController`, `UserRepository`, `HospitalRepository`, `PolicyRepository`
    - 최근 활동 조회를 top-N 쿼리 기반으로 변경
    - 월별 가입자 추이를 DB group-by 집계로 대체

### 3) 운영/품질(P2)
- CI/CD 워크플로 개선
  - `.github/workflows/ci-cd.yml`
    - `permissions` 최소 권한 명시
    - `concurrency` 설정 추가
    - Trivy action 버전 고정 (`@master` 제거)
    - 배포/헬스체크/롤백 단계를 실제 명령 기반으로 보강 (secret 기반)
- Docker 런타임 하드닝
  - `Dockerfile`
    - build image를 wrapper 버전에 정렬(Gradle 8.14.2)
    - non-root 사용자 실행
    - `HEALTHCHECK` 추가
    - JVM 옵션 적용
    - 포트 `8082` 기준으로 정합화
- 품질 게이트 기반 추가
  - `build.gradle`
    - Jacoco 플러그인 추가
    - 리포트 생성 및 커버리지 검증 task chain 연결
- 기타 운영 정합성
  - `.dockerignore` 신규 추가
  - `scripts/generate-asciidoc.sh` 헬스체크 경로를 `/actuator/health`로 수정

### 4) 참고 이슈
- Closes #36

## 🏫 테스트 결과
### 로컬 수행
- [x] `./gradlew compileJava` 통과
- [ ] `./gradlew test`
  - 실패(기존 환경/테스트 이슈 포함)
  - 확인된 내용
    - 테스트 컨텍스트에서 DB 인증 관련 연결 실패
    - 기존 `HealthServiceTest` 일부 케이스 실패

### 확인 포인트
- 본 PR에서 수정한 클래스들은 컴파일 및 linter 경고 없이 정리됨
- 테스트 실패는 기존 환경 의존/레거시 테스트 이슈 성격으로 별도 트래킹 필요

## 🏫 To Reviewer
- 우선 리뷰 요청 포인트
  1. `SecurityConfig`의 CORS allowlist/actuator 접근 정책이 운영 정책과 맞는지
  2. `JwtService` fail-fast 조건(길이 기준 포함)이 현재 secret 운영 방식과 충돌 없는지
  3. `HospitalRepository`/`UserRepository` 집계 쿼리의 DB 실행계획(인덱스 필요 여부)
  4. CI/CD에서 추가한 secret 기반 배포/롤백 단계의 현실 운영 적합성
- 배포 전 체크 요청
  - staging secrets 세팅 후 workflow 수동 실행
  - `/actuator/health` 및 핵심 API smoke test