### PR TITLE
FIX : 폐기된 openjdk 베이스 이미지를 eclipse-temurin 으로 교체 (#77)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,15 @@ COPY . .
 RUN gradle clean bootJar --no-daemon
 
 # 2단계: JDK 17로 실행용 이미지 구성
-FROM openjdk:17-jdk-slim
+#
+# openjdk 공식 이미지는 폐기되어 Docker Hub 에서 태그가 내려갔다. openjdk:17-jdk-slim 은
+# 더 이상 존재하지 않아 이미지 빌드가 "not found" 로 실패한다. Docker 가 후속으로 안내하는
+# eclipse-temurin 으로 옮긴다.
+#
+# JRE 가 아니라 JDK 를 쓰는 건 이전과 같다. 운영 중 jcmd·jstack 으로 들여다보던 걸
+# 이 교체 때문에 잃지 않도록 한다. (이미지 크기를 줄이려면 -jre-jammy 로 바꿀 수 있는데,
+# 아래 HEALTHCHECK 의 wget 과 addgroup/adduser 는 그쪽에도 모두 있다.)
+FROM eclipse-temurin:17-jdk-jammy
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
## 개요

`main` 에 푸시될 때마다 `Build Docker Image` 가 실패해 배포 잡이 모두 skip 되고 있었습니다.
머지는 되지만 **배포는 되지 않는 상태가 8월 4일부터 이어졌습니다.**

Fixes #77

## 원인

`openjdk` 공식 이미지가 폐기되어 Docker Hub 에서 태그가 내려갔습니다.

```
ERROR: failed to solve: openjdk:17-jdk-slim: failed to resolve source metadata
  for docker.io/library/openjdk:17-jdk-slim: not found
```

- 2026-08-04 PR #60 머지 → 실패 (run 30876594333)
- 2026-08-10 PR #66 머지 → 같은 오류로 실패 (run 31360981048)

## 변경 사항

Dockerfile 2단계 베이스 이미지를 `openjdk:17-jdk-slim` → `eclipse-temurin:17-jdk-jammy` 로
교체합니다. 그 외 변경은 없습니다.

## 기술적 상세 설명

**JRE 가 아니라 JDK 를 고른 이유** — 이전이 JDK 였습니다. 운영 중 `jcmd`·`jstack` 으로
들여다보던 걸 이 교체 때문에 잃지 않도록, 동작을 바꾸지 않는 쪽으로 뒀습니다.
이미지 크기는 `-jdk-jammy` 1.26GB / `-jre-jammy` 998MB 이고, 크기를 택하려면 한 줄만
바꾸면 됩니다. HEALTHCHECK 의 `wget` 과 `addgroup`/`adduser` 는 양쪽 모두에 있습니다.

**검증** — 로컬에서 실제로 빌드해 확인했습니다.

- 이미지 빌드 성공 (gradle 빌드 단계 포함, exit 0)
- `/app/app.jar` 정상 포함 (163MB)
- `uid=101(carecode)` 비root 실행 유지
- `wget` 존재 → HEALTHCHECK 동작
- `java 17.0.19`

## 체크리스트

- [x] 빌드가 정상적으로 통과됐습니다.

## 추가 정보

이 PR 이 머지되면 **8월 4일 이후 `main` 에 쌓인 변경이 한꺼번에 프로덕션에 나갑니다**
(PR #60, #66 포함). 롤백 대상이 크다는 점을 감안해주세요.
